### PR TITLE
bugfix for sh comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,6 @@ $acme_domain_validation_method['dns_zoneedit'] = array('name' => "DNS-Zoneedit",
                 ),
                 'ZONEEDIT_Token' => array('name' => "zoneedit_token", 'columnheader' => "Token", 'type' => "textbox",
                         'description' => "ZONEEDIT Token"
-                        )$acme_domain_validation_method['dns_zoneedit'] = array('name' => "DNS-Zoneedit",
-        'fields' => array(
-                'ZONEEDIT_ID' => array('name' => "zoneedit_id", 'columnheader' => "ID", 'type' => "textbox",
-                        'description' => "ZONEEDIT ID"
-                ),
-                'ZONEEDIT_Token' => array('name' => "zoneedit_token", 'columnheader' => "Token", 'type' => "textbox",
-                        'description' => "ZONEEDIT Token"
                         )
         ));
 ```

--- a/dns_zoneedit.sh
+++ b/dns_zoneedit.sh
@@ -128,7 +128,7 @@ _get_root() {
 
   # Get the root domain
   ndots=$(echo $fulldomain | tr -dc '.' | wc -c)
-  if [ "$ndots" < "2" ]; then
+  if [ "$ndots" -lt "2" ]; then
       # invalid fulldomain
       _err "Invalid fulldomain"
       return 1


### PR DESCRIPTION
Your syntax fails under docker as well as recent pfSense hosts (21.x/2.5.x), where this tries to redirect file "2".  I think you need `-lt` per https://www.joedog.org/articles-cheat-sheet/.

The `README` file also appears to include a duplicated `inc` paste.
