### PR TITLE
pfsense requires success for missing delete on zoneedit api

### DIFF
--- a/dns_zoneedit.sh
+++ b/dns_zoneedit.sh
@@ -99,6 +99,10 @@ dns_zoneedit_rm() {
   _debug _sub_domain "$_sub_domain"
   _debug _domain "$_domain"
 
+  # TODO: ZoneEdit does not implement delete yet but applications,
+  # such as pfsense, require a successful return code to update the cert.
+  _info "Delete txt record not implemented yet"
+  return 0
   # if _zoneedit_api "DELETE" "$fulldomain" "$txtvalue"; then
   #   if printf -- "%s" "$response" | grep "OK." >/dev/null; then
   #     _info "Deleted, OK"
@@ -108,7 +112,6 @@ dns_zoneedit_rm() {
   #     return 1
   #   fi
   # fi
-  _info "Delete txt record not implemented yet"
 
   return 1
 }


### PR DESCRIPTION
pfSense now checks the return code for the TXT delete following the DNS update and requires a clean return code before it will rotate to the new certificate.  The existing code returns failure, so you're left with the old certificate.

If you're using this with the latest version, I'm assuming you're also seeing it on your end.

Until ZoneEdit implements the TXT delete feature, I had to modify the code to provide the expected return.  I left your commented block following which can be enabled once they add API support.
